### PR TITLE
Refactor/table cell identifier

### DIFF
--- a/JRNL-Programmatically/View/Component/JournalTableCell.swift
+++ b/JRNL-Programmatically/View/Component/JournalTableCell.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 final class JournalTableCell: UITableViewCell {
+    static let identifier = "JournalTableCell"
     
     // MARK: - Components
     private lazy var titleLabel: UILabel = {

--- a/JRNL-Programmatically/View/JournalFlow/JournalListViewController.swift
+++ b/JRNL-Programmatically/View/JournalFlow/JournalListViewController.swift
@@ -85,7 +85,10 @@ extension JournalListViewController: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: "journalCell", for: indexPath) as? JournalTableCell else {
+        guard let cell = tableView.dequeueReusableCell(
+            withIdentifier: JournalTableCell.identifier,
+            for: indexPath
+        ) as? JournalTableCell else {
             return UITableViewCell()
         }
         cell.setup(with: viewModel.journals[indexPath.row])


### PR DESCRIPTION
## Changes
- `JournalTableCell` has type property, implying explictly the identifer of itself