### PR TITLE
Feature/journal detail table view

### DIFF
--- a/JRNL-Programmatically.xcodeproj/project.pbxproj
+++ b/JRNL-Programmatically.xcodeproj/project.pbxproj
@@ -25,12 +25,13 @@
 		83F4A58A2BEE237300CC3C4B /* Journal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F4A5892BEE237300CC3C4B /* Journal.swift */; };
 		83F4A58D2BEE245F00CC3C4B /* JournalMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F4A58C2BEE245F00CC3C4B /* JournalMock.swift */; };
 		83F4A5912BEE263B00CC3C4B /* JournalListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F4A5902BEE263B00CC3C4B /* JournalListViewModel.swift */; };
-		83F4A5932BEE399D00CC3C4B /* JournalDetailTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F4A5922BEE399D00CC3C4B /* JournalDetailTableView.swift */; };
+		83F4A5932BEE399D00CC3C4B /* JournalDetailTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F4A5922BEE399D00CC3C4B /* JournalDetailTableViewController.swift */; };
 		83F4A5972BEE408400CC3C4B /* JournalDetailTableLabelCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F4A5962BEE408400CC3C4B /* JournalDetailTableLabelCell.swift */; };
 		83F4A59A2BEE417F00CC3C4B /* JournalDetailTableTextCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F4A5992BEE417F00CC3C4B /* JournalDetailTableTextCell.swift */; };
 		83F4A59C2BEE41F200CC3C4B /* JournalDetailTableImageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F4A59B2BEE41F200CC3C4B /* JournalDetailTableImageCell.swift */; };
 		83F4A59F2BEE47C200CC3C4B /* CommonField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F4A59E2BEE47C200CC3C4B /* CommonField.swift */; };
 		83F4A5A42BEE489200CC3C4B /* BaseTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F4A5A32BEE489200CC3C4B /* BaseTableViewCell.swift */; };
+		83F4A5AE2BEE4E1300CC3C4B /* CellContentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F4A5AD2BEE4E1300CC3C4B /* CellContentType.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -73,12 +74,13 @@
 		83F4A5892BEE237300CC3C4B /* Journal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Journal.swift; sourceTree = "<group>"; };
 		83F4A58C2BEE245F00CC3C4B /* JournalMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JournalMock.swift; sourceTree = "<group>"; };
 		83F4A5902BEE263B00CC3C4B /* JournalListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JournalListViewModel.swift; sourceTree = "<group>"; };
-		83F4A5922BEE399D00CC3C4B /* JournalDetailTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JournalDetailTableView.swift; sourceTree = "<group>"; };
+		83F4A5922BEE399D00CC3C4B /* JournalDetailTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JournalDetailTableViewController.swift; sourceTree = "<group>"; };
 		83F4A5962BEE408400CC3C4B /* JournalDetailTableLabelCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JournalDetailTableLabelCell.swift; sourceTree = "<group>"; };
 		83F4A5992BEE417F00CC3C4B /* JournalDetailTableTextCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JournalDetailTableTextCell.swift; sourceTree = "<group>"; };
 		83F4A59B2BEE41F200CC3C4B /* JournalDetailTableImageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JournalDetailTableImageCell.swift; sourceTree = "<group>"; };
 		83F4A59E2BEE47C200CC3C4B /* CommonField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonField.swift; sourceTree = "<group>"; };
 		83F4A5A32BEE489200CC3C4B /* BaseTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTableViewCell.swift; sourceTree = "<group>"; };
+		83F4A5AD2BEE4E1300CC3C4B /* CellContentType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellContentType.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -204,7 +206,7 @@
 			children = (
 				83182F0F2BECCE3A00F81A7C /* JournalListViewController.swift */,
 				83182F202BECE92600F81A7C /* AddJournalViewController.swift */,
-				83F4A5922BEE399D00CC3C4B /* JournalDetailTableView.swift */,
+				83F4A5922BEE399D00CC3C4B /* JournalDetailTableViewController.swift */,
 			);
 			path = JournalFlow;
 			sourceTree = "<group>";
@@ -288,6 +290,7 @@
 			isa = PBXGroup;
 			children = (
 				83F4A5A32BEE489200CC3C4B /* BaseTableViewCell.swift */,
+				83F4A5AD2BEE4E1300CC3C4B /* CellContentType.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -434,13 +437,14 @@
 				83182F102BECCE3A00F81A7C /* JournalListViewController.swift in Sources */,
 				83F4A58A2BEE237300CC3C4B /* Journal.swift in Sources */,
 				83182F172BECD8B400F81A7C /* RootTabBarController.swift in Sources */,
+				83F4A5AE2BEE4E1300CC3C4B /* CellContentType.swift in Sources */,
 				83F4A59F2BEE47C200CC3C4B /* CommonField.swift in Sources */,
 				83F4A5A42BEE489200CC3C4B /* BaseTableViewCell.swift in Sources */,
 				83182F212BECE92600F81A7C /* AddJournalViewController.swift in Sources */,
 				83182EE32BECCDD700F81A7C /* ViewController.swift in Sources */,
 				83182F132BECCF0900F81A7C /* JournalTableCell.swift in Sources */,
 				83182EDF2BECCDD700F81A7C /* AppDelegate.swift in Sources */,
-				83F4A5932BEE399D00CC3C4B /* JournalDetailTableView.swift in Sources */,
+				83F4A5932BEE399D00CC3C4B /* JournalDetailTableViewController.swift in Sources */,
 				83F4A5972BEE408400CC3C4B /* JournalDetailTableLabelCell.swift in Sources */,
 				83182EE12BECCDD700F81A7C /* SceneDelegate.swift in Sources */,
 				83F4A59A2BEE417F00CC3C4B /* JournalDetailTableTextCell.swift in Sources */,

--- a/JRNL-Programmatically.xcodeproj/project.pbxproj
+++ b/JRNL-Programmatically.xcodeproj/project.pbxproj
@@ -25,6 +25,11 @@
 		83F4A58A2BEE237300CC3C4B /* Journal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F4A5892BEE237300CC3C4B /* Journal.swift */; };
 		83F4A58D2BEE245F00CC3C4B /* JournalMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F4A58C2BEE245F00CC3C4B /* JournalMock.swift */; };
 		83F4A5912BEE263B00CC3C4B /* JournalListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F4A5902BEE263B00CC3C4B /* JournalListViewModel.swift */; };
+		83F4A5932BEE399D00CC3C4B /* JournalDetailTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F4A5922BEE399D00CC3C4B /* JournalDetailTableView.swift */; };
+		83F4A5972BEE408400CC3C4B /* JournalDetailTableLabelCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F4A5962BEE408400CC3C4B /* JournalDetailTableLabelCell.swift */; };
+		83F4A59A2BEE417F00CC3C4B /* JournalDetailTableTextCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F4A5992BEE417F00CC3C4B /* JournalDetailTableTextCell.swift */; };
+		83F4A59C2BEE41F200CC3C4B /* JournalDetailTableImageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F4A59B2BEE41F200CC3C4B /* JournalDetailTableImageCell.swift */; };
+		83F4A59F2BEE47C200CC3C4B /* CommonField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F4A59E2BEE47C200CC3C4B /* CommonField.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -67,6 +72,11 @@
 		83F4A5892BEE237300CC3C4B /* Journal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Journal.swift; sourceTree = "<group>"; };
 		83F4A58C2BEE245F00CC3C4B /* JournalMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JournalMock.swift; sourceTree = "<group>"; };
 		83F4A5902BEE263B00CC3C4B /* JournalListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JournalListViewModel.swift; sourceTree = "<group>"; };
+		83F4A5922BEE399D00CC3C4B /* JournalDetailTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JournalDetailTableView.swift; sourceTree = "<group>"; };
+		83F4A5962BEE408400CC3C4B /* JournalDetailTableLabelCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JournalDetailTableLabelCell.swift; sourceTree = "<group>"; };
+		83F4A5992BEE417F00CC3C4B /* JournalDetailTableTextCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JournalDetailTableTextCell.swift; sourceTree = "<group>"; };
+		83F4A59B2BEE41F200CC3C4B /* JournalDetailTableImageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JournalDetailTableImageCell.swift; sourceTree = "<group>"; };
+		83F4A59E2BEE47C200CC3C4B /* CommonField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonField.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -162,6 +172,7 @@
 		83182F112BECCEEC00F81A7C /* Component */ = {
 			isa = PBXGroup;
 			children = (
+				83F4A59D2BEE47B900CC3C4B /* Field */,
 				83182F122BECCF0900F81A7C /* JournalTableCell.swift */,
 			);
 			path = Component;
@@ -190,6 +201,7 @@
 			children = (
 				83182F0F2BECCE3A00F81A7C /* JournalListViewController.swift */,
 				83182F202BECE92600F81A7C /* AddJournalViewController.swift */,
+				83F4A5922BEE399D00CC3C4B /* JournalDetailTableView.swift */,
 			);
 			path = JournalFlow;
 			sourceTree = "<group>";
@@ -232,6 +244,41 @@
 				83F4A5902BEE263B00CC3C4B /* JournalListViewModel.swift */,
 			);
 			path = JournalFlow;
+			sourceTree = "<group>";
+		};
+		83F4A59D2BEE47B900CC3C4B /* Field */ = {
+			isa = PBXGroup;
+			children = (
+				83F4A5A22BEE482500CC3C4B /* TextField */,
+				83F4A5A12BEE481D00CC3C4B /* ImageField */,
+				83F4A5A02BEE47F500CC3C4B /* LabelField */,
+				83F4A59E2BEE47C200CC3C4B /* CommonField.swift */,
+			);
+			path = Field;
+			sourceTree = "<group>";
+		};
+		83F4A5A02BEE47F500CC3C4B /* LabelField */ = {
+			isa = PBXGroup;
+			children = (
+				83F4A5962BEE408400CC3C4B /* JournalDetailTableLabelCell.swift */,
+			);
+			path = LabelField;
+			sourceTree = "<group>";
+		};
+		83F4A5A12BEE481D00CC3C4B /* ImageField */ = {
+			isa = PBXGroup;
+			children = (
+				83F4A59B2BEE41F200CC3C4B /* JournalDetailTableImageCell.swift */,
+			);
+			path = ImageField;
+			sourceTree = "<group>";
+		};
+		83F4A5A22BEE482500CC3C4B /* TextField */ = {
+			isa = PBXGroup;
+			children = (
+				83F4A5992BEE417F00CC3C4B /* JournalDetailTableTextCell.swift */,
+			);
+			path = TextField;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -368,15 +415,20 @@
 				83182F102BECCE3A00F81A7C /* JournalListViewController.swift in Sources */,
 				83F4A58A2BEE237300CC3C4B /* Journal.swift in Sources */,
 				83182F172BECD8B400F81A7C /* RootTabBarController.swift in Sources */,
+				83F4A59F2BEE47C200CC3C4B /* CommonField.swift in Sources */,
 				83182F212BECE92600F81A7C /* AddJournalViewController.swift in Sources */,
 				83182EE32BECCDD700F81A7C /* ViewController.swift in Sources */,
 				83182F132BECCF0900F81A7C /* JournalTableCell.swift in Sources */,
 				83182EDF2BECCDD700F81A7C /* AppDelegate.swift in Sources */,
+				83F4A5932BEE399D00CC3C4B /* JournalDetailTableView.swift in Sources */,
+				83F4A5972BEE408400CC3C4B /* JournalDetailTableLabelCell.swift in Sources */,
 				83182EE12BECCDD700F81A7C /* SceneDelegate.swift in Sources */,
+				83F4A59A2BEE417F00CC3C4B /* JournalDetailTableTextCell.swift in Sources */,
 				83F4A5912BEE263B00CC3C4B /* JournalListViewModel.swift in Sources */,
 				83182F192BECE14A00F81A7C /* MapViewController.swift in Sources */,
 				83F4A58D2BEE245F00CC3C4B /* JournalMock.swift in Sources */,
 				83182F1C2BECE40600F81A7C /* AppAppearance.swift in Sources */,
+				83F4A59C2BEE41F200CC3C4B /* JournalDetailTableImageCell.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/JRNL-Programmatically.xcodeproj/project.pbxproj
+++ b/JRNL-Programmatically.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		83F4A59A2BEE417F00CC3C4B /* JournalDetailTableTextCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F4A5992BEE417F00CC3C4B /* JournalDetailTableTextCell.swift */; };
 		83F4A59C2BEE41F200CC3C4B /* JournalDetailTableImageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F4A59B2BEE41F200CC3C4B /* JournalDetailTableImageCell.swift */; };
 		83F4A59F2BEE47C200CC3C4B /* CommonField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F4A59E2BEE47C200CC3C4B /* CommonField.swift */; };
+		83F4A5A42BEE489200CC3C4B /* BaseTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F4A5A32BEE489200CC3C4B /* BaseTableViewCell.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -77,6 +78,7 @@
 		83F4A5992BEE417F00CC3C4B /* JournalDetailTableTextCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JournalDetailTableTextCell.swift; sourceTree = "<group>"; };
 		83F4A59B2BEE41F200CC3C4B /* JournalDetailTableImageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JournalDetailTableImageCell.swift; sourceTree = "<group>"; };
 		83F4A59E2BEE47C200CC3C4B /* CommonField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonField.swift; sourceTree = "<group>"; };
+		83F4A5A32BEE489200CC3C4B /* BaseTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTableViewCell.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -172,8 +174,9 @@
 		83182F112BECCEEC00F81A7C /* Component */ = {
 			isa = PBXGroup;
 			children = (
+				83F4A5A62BEE48C400CC3C4B /* JournalTable */,
+				83F4A5A52BEE48B700CC3C4B /* Common */,
 				83F4A59D2BEE47B900CC3C4B /* Field */,
-				83182F122BECCF0900F81A7C /* JournalTableCell.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -279,6 +282,22 @@
 				83F4A5992BEE417F00CC3C4B /* JournalDetailTableTextCell.swift */,
 			);
 			path = TextField;
+			sourceTree = "<group>";
+		};
+		83F4A5A52BEE48B700CC3C4B /* Common */ = {
+			isa = PBXGroup;
+			children = (
+				83F4A5A32BEE489200CC3C4B /* BaseTableViewCell.swift */,
+			);
+			path = Common;
+			sourceTree = "<group>";
+		};
+		83F4A5A62BEE48C400CC3C4B /* JournalTable */ = {
+			isa = PBXGroup;
+			children = (
+				83182F122BECCF0900F81A7C /* JournalTableCell.swift */,
+			);
+			path = JournalTable;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -416,6 +435,7 @@
 				83F4A58A2BEE237300CC3C4B /* Journal.swift in Sources */,
 				83182F172BECD8B400F81A7C /* RootTabBarController.swift in Sources */,
 				83F4A59F2BEE47C200CC3C4B /* CommonField.swift in Sources */,
+				83F4A5A42BEE489200CC3C4B /* BaseTableViewCell.swift in Sources */,
 				83182F212BECE92600F81A7C /* AddJournalViewController.swift in Sources */,
 				83182EE32BECCDD700F81A7C /* ViewController.swift in Sources */,
 				83182F132BECCF0900F81A7C /* JournalTableCell.swift in Sources */,

--- a/JRNL-Programmatically.xcodeproj/project.pbxproj
+++ b/JRNL-Programmatically.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		83F4A59F2BEE47C200CC3C4B /* CommonField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F4A59E2BEE47C200CC3C4B /* CommonField.swift */; };
 		83F4A5A42BEE489200CC3C4B /* BaseTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F4A5A32BEE489200CC3C4B /* BaseTableViewCell.swift */; };
 		83F4A5AE2BEE4E1300CC3C4B /* CellContentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F4A5AD2BEE4E1300CC3C4B /* CellContentType.swift */; };
+		83F4A5B02BEE665500CC3C4B /* JournalDetailTableViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F4A5AF2BEE665500CC3C4B /* JournalDetailTableViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -81,6 +82,7 @@
 		83F4A59E2BEE47C200CC3C4B /* CommonField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonField.swift; sourceTree = "<group>"; };
 		83F4A5A32BEE489200CC3C4B /* BaseTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTableViewCell.swift; sourceTree = "<group>"; };
 		83F4A5AD2BEE4E1300CC3C4B /* CellContentType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellContentType.swift; sourceTree = "<group>"; };
+		83F4A5AF2BEE665500CC3C4B /* JournalDetailTableViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JournalDetailTableViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -247,6 +249,7 @@
 			isa = PBXGroup;
 			children = (
 				83F4A5902BEE263B00CC3C4B /* JournalListViewModel.swift */,
+				83F4A5AF2BEE665500CC3C4B /* JournalDetailTableViewModel.swift */,
 			);
 			path = JournalFlow;
 			sourceTree = "<group>";
@@ -448,6 +451,7 @@
 				83F4A5972BEE408400CC3C4B /* JournalDetailTableLabelCell.swift in Sources */,
 				83182EE12BECCDD700F81A7C /* SceneDelegate.swift in Sources */,
 				83F4A59A2BEE417F00CC3C4B /* JournalDetailTableTextCell.swift in Sources */,
+				83F4A5B02BEE665500CC3C4B /* JournalDetailTableViewModel.swift in Sources */,
 				83F4A5912BEE263B00CC3C4B /* JournalListViewModel.swift in Sources */,
 				83182F192BECE14A00F81A7C /* MapViewController.swift in Sources */,
 				83F4A58D2BEE245F00CC3C4B /* JournalMock.swift in Sources */,

--- a/JRNL-Programmatically/View/Component/Common/BaseTableViewCell.swift
+++ b/JRNL-Programmatically/View/Component/Common/BaseTableViewCell.swift
@@ -1,0 +1,22 @@
+//
+//  BaseTableViewCell.swift
+//  JRNL-Programmatically
+//
+//  Created by jinwoong Kim on 5/10/24.
+//
+
+import UIKit
+
+class BaseTableViewCell: UITableViewCell {
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        
+        configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func configureUI() { }
+}

--- a/JRNL-Programmatically/View/Component/Common/BaseTableViewCell.swift
+++ b/JRNL-Programmatically/View/Component/Common/BaseTableViewCell.swift
@@ -8,6 +8,8 @@
 import UIKit
 
 class BaseTableViewCell: UITableViewCell {
+    class var identifier: String { "BaseTableViewCell" }
+    
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         
@@ -19,4 +21,6 @@ class BaseTableViewCell: UITableViewCell {
     }
     
     func configureUI() { }
+    
+    func setup(with contentType: CellContentType) { }
 }

--- a/JRNL-Programmatically/View/Component/Common/CellContentType.swift
+++ b/JRNL-Programmatically/View/Component/Common/CellContentType.swift
@@ -1,0 +1,14 @@
+//
+//  CellContentType.swift
+//  JRNL-Programmatically
+//
+//  Created by jinwoong Kim on 5/10/24.
+//
+
+import UIKit
+
+enum CellContentType {
+    case label(String, NSTextAlignment)
+    case text(String)
+    case image(String)
+}

--- a/JRNL-Programmatically/View/Component/Field/CommonField.swift
+++ b/JRNL-Programmatically/View/Component/Field/CommonField.swift
@@ -1,0 +1,13 @@
+//
+//  CommonField.swift
+//  JRNL-Programmatically
+//
+//  Created by jinwoong Kim on 5/10/24.
+//
+
+import UIKit
+
+protocol CommonField {
+    func register(for tableView: UITableView)
+    func dequeue(for tableView: UITableView, at indexPath: IndexPath) -> UITableViewCell
+}

--- a/JRNL-Programmatically/View/Component/Field/CommonField.swift
+++ b/JRNL-Programmatically/View/Component/Field/CommonField.swift
@@ -7,9 +7,7 @@
 
 import UIKit
 
-protocol CommonField<CellType> {
-    associatedtype CellType: BaseTableViewCell
-    
+protocol CommonField {
     var cellContentType: CellContentType { get }
     var height: CGFloat? { get }
     

--- a/JRNL-Programmatically/View/Component/Field/CommonField.swift
+++ b/JRNL-Programmatically/View/Component/Field/CommonField.swift
@@ -7,7 +7,30 @@
 
 import UIKit
 
-protocol CommonField {
+protocol CommonField<CellType> {
+    associatedtype CellType: BaseTableViewCell
+    
+    var cellContentType: CellContentType { get }
+    var height: CGFloat? { get }
+    
     func register(for tableView: UITableView)
     func dequeue(for tableView: UITableView, at indexPath: IndexPath) -> UITableViewCell
+}
+
+struct CellField<CellType: BaseTableViewCell>: CommonField {
+    var cellContentType: CellContentType
+    var height: CGFloat? = nil
+    
+    func register(for tableView: UITableView) {
+        tableView.register(CellType.self, forCellReuseIdentifier: CellType.identifier)
+    }
+    
+    func dequeue(for tableView: UITableView, at indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: CellType.identifier, for: indexPath) as? CellType else {
+            return UITableViewCell()
+        }
+        cell.setup(with: cellContentType)
+        
+        return cell
+    }
 }

--- a/JRNL-Programmatically/View/Component/Field/ImageField/JournalDetailTableImageCell.swift
+++ b/JRNL-Programmatically/View/Component/Field/ImageField/JournalDetailTableImageCell.swift
@@ -1,0 +1,44 @@
+//
+//  JournalDetailTableImageCell.swift
+//  JRNL-Programmatically
+//
+//  Created by jinwoong Kim on 5/10/24.
+//
+
+import UIKit
+
+final class JournalDetailTableImageCell: BaseTableViewCell {
+    override class var identifier: String { "JournalDetailTableImageCell" }
+    
+    // MARK - Components
+    private lazy var journalImageView: UIImageView = {
+        let journalImageView = UIImageView()
+        journalImageView.contentMode = .scaleAspectFit
+        
+        return journalImageView
+    }()
+    
+    override func configureUI() {
+        addSubview(journalImageView)
+
+        journalImageView.translatesAutoresizingMaskIntoConstraints = false
+
+        let global = safeAreaLayoutGuide
+        
+        NSLayoutConstraint.activate([
+            journalImageView.widthAnchor.constraint(equalToConstant: 300),
+            journalImageView.heightAnchor.constraint(equalToConstant: 300),
+            journalImageView.centerXAnchor.constraint(equalTo: global.centerXAnchor),
+            journalImageView.centerYAnchor.constraint(equalTo: global.centerYAnchor),
+        ])
+    }
+    
+    override func setup(with contentType: CellContentType) {
+        if case let .image(imageString) = contentType {
+            journalImageView.image = UIImage(systemName: imageString)
+        } else {
+            debugPrint("JournalDetailTableImageCell setup(with:) malfucntioning")
+        }
+    }
+}
+

--- a/JRNL-Programmatically/View/Component/Field/LabelField/JournalDetailTableLabelCell.swift
+++ b/JRNL-Programmatically/View/Component/Field/LabelField/JournalDetailTableLabelCell.swift
@@ -1,0 +1,40 @@
+//
+//  JournalDetailTableLabelCell.swift
+//  JRNL-Programmatically
+//
+//  Created by jinwoong Kim on 5/10/24.
+//
+
+import UIKit
+
+final class JournalDetailTableLabelCell: BaseTableViewCell {
+    override class var identifier: String { "JournalDetailTableLabelCell" }
+    
+    // MARK - Components
+    private lazy var label: UILabel = {
+        let label = UILabel()
+        
+        return label
+    }()
+    
+    override func configureUI() {
+        addSubview(label)
+        
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
+        let marginGuide = layoutMarginsGuide
+        
+        NSLayoutConstraint.activate([
+            label.topAnchor.constraint(equalTo: marginGuide.topAnchor),
+            label.leadingAnchor.constraint(equalTo: marginGuide.leadingAnchor),
+            label.trailingAnchor.constraint(equalTo: marginGuide.trailingAnchor),
+        ])
+    }
+    
+    override func setup(with contentType: CellContentType) {
+        if case let .label(labelString, labelAlignment) = contentType {
+            label.text = labelString
+            label.textAlignment = labelAlignment
+        }
+    }
+}

--- a/JRNL-Programmatically/View/Component/Field/TextField/JournalDetailTableTextCell.swift
+++ b/JRNL-Programmatically/View/Component/Field/TextField/JournalDetailTableTextCell.swift
@@ -1,0 +1,40 @@
+//
+//  JournalDetailTableTextCell.swift
+//  JRNL-Programmatically
+//
+//  Created by jinwoong Kim on 5/10/24.
+//
+
+import UIKit
+
+final class JournalDetailTableTextCell: BaseTableViewCell {
+    override class var identifier: String { "JournalDetailTableTextCell" }
+    
+    // MARK - Components
+    private lazy var textView: UITextView = {
+        let textView = UITextView()
+        
+        return textView
+    }()
+    
+    override func configureUI() {
+        contentView.addSubview(textView)
+
+        textView.translatesAutoresizingMaskIntoConstraints = false
+
+        let marginGuide = layoutMarginsGuide
+        
+        NSLayoutConstraint.activate([
+            textView.topAnchor.constraint(equalTo: marginGuide.topAnchor),
+            textView.leadingAnchor.constraint(equalTo: marginGuide.leadingAnchor),
+            textView.trailingAnchor.constraint(equalTo: marginGuide.trailingAnchor),
+            textView.bottomAnchor.constraint(equalTo: marginGuide.bottomAnchor)
+        ])
+    }
+
+    override func setup(with contentType: CellContentType) {
+        if case let .text(textString) = contentType {
+            textView.text = textString
+        }
+    }
+}

--- a/JRNL-Programmatically/View/Component/JournalTable/JournalTableCell.swift
+++ b/JRNL-Programmatically/View/Component/JournalTable/JournalTableCell.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 final class JournalTableCell: BaseTableViewCell {
-    static let identifier = "JournalTableCell"
+    override class var identifier: String { "JournalTableCell" }
     
     // MARK: - Components
     private lazy var titleLabel: UILabel = {
@@ -28,7 +28,8 @@ final class JournalTableCell: BaseTableViewCell {
     
     private lazy var thumbnailView: UIImageView = {
         let thumbnailView = UIImageView()
-        thumbnailView.image = UIImage(systemName: "face.smiling")
+        thumbnailView.image = UIImage(systemName: "face.smiling")?.withRenderingMode(.automatic)
+        thumbnailView.contentMode = .scaleAspectFit
         
         return thumbnailView
     }()
@@ -43,6 +44,7 @@ final class JournalTableCell: BaseTableViewCell {
         descriptionLabel.translatesAutoresizingMaskIntoConstraints = false
         
         let global = safeAreaLayoutGuide
+        let marginGuide = layoutMarginsGuide
         
         NSLayoutConstraint.activate([
             thumbnailView.topAnchor.constraint(equalTo: global.topAnchor),
@@ -50,13 +52,13 @@ final class JournalTableCell: BaseTableViewCell {
             thumbnailView.bottomAnchor.constraint(equalTo: global.bottomAnchor),
             thumbnailView.widthAnchor.constraint(equalToConstant: 90),
             
-            titleLabel.topAnchor.constraint(equalTo: global.topAnchor),
+            titleLabel.topAnchor.constraint(equalTo: marginGuide.topAnchor),
             titleLabel.leadingAnchor.constraint(equalTo: thumbnailView.trailingAnchor, constant: 8),
-            titleLabel.trailingAnchor.constraint(equalTo: global.trailingAnchor, constant: 8),
+            titleLabel.trailingAnchor.constraint(equalTo: marginGuide.trailingAnchor, constant: 8),
             
             descriptionLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 8),
             descriptionLabel.leadingAnchor.constraint(equalTo: thumbnailView.trailingAnchor, constant: 8),
-            descriptionLabel.trailingAnchor.constraint(equalTo: global.trailingAnchor, constant: 8)
+            descriptionLabel.trailingAnchor.constraint(equalTo: marginGuide.trailingAnchor, constant: 8)
         ])
     }
     

--- a/JRNL-Programmatically/View/Component/JournalTable/JournalTableCell.swift
+++ b/JRNL-Programmatically/View/Component/JournalTable/JournalTableCell.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class JournalTableCell: UITableViewCell {
+final class JournalTableCell: BaseTableViewCell {
     static let identifier = "JournalTableCell"
     
     // MARK: - Components
@@ -33,22 +33,11 @@ final class JournalTableCell: UITableViewCell {
         return thumbnailView
     }()
     
-    
-    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        super.init(style: style, reuseIdentifier: reuseIdentifier)
-        
+    override func configureUI() {
         addSubview(thumbnailView)
         addSubview(titleLabel)
         addSubview(descriptionLabel)
         
-        configureUI()
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
-    private func configureUI() {
         thumbnailView.translatesAutoresizingMaskIntoConstraints = false
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         descriptionLabel.translatesAutoresizingMaskIntoConstraints = false

--- a/JRNL-Programmatically/View/JournalFlow/JournalDetailTableViewController.swift
+++ b/JRNL-Programmatically/View/JournalFlow/JournalDetailTableViewController.swift
@@ -1,0 +1,51 @@
+//
+//  JournalDetailTableViewController.swift
+//  JRNL-Programmatically
+//
+//  Created by jinwoong Kim on 5/10/24.
+//
+
+import UIKit
+
+final class JournalDetailTableViewController: UITableViewController {
+    private let viewModel: JournalDetailTableViewModel
+    
+    init(viewModel: JournalDetailTableViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Life Cycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        register()
+    }
+    
+    private func register() {
+        viewModel.fields.forEach { field in
+            field.register(for: self.tableView)
+        }
+    }
+    
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let field = viewModel.fields[indexPath.row]
+        return field.dequeue(for: tableView, at: indexPath)
+    }
+    
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        viewModel.fields.count
+    }
+    
+    override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        if let height = viewModel.fields[indexPath.row].height {
+            return height
+        } else {
+            return UITableView.automaticDimension
+        }
+    }
+}

--- a/JRNL-Programmatically/View/JournalFlow/JournalListViewController.swift
+++ b/JRNL-Programmatically/View/JournalFlow/JournalListViewController.swift
@@ -32,7 +32,7 @@ final class JournalListViewController: UIViewController {
         
         tableView.delegate = self
         tableView.dataSource = self
-        tableView.register(JournalTableCell.self, forCellReuseIdentifier: "journalCell")
+        tableView.register(JournalTableCell.self, forCellReuseIdentifier: JournalTableCell.identifier)
         
         configureUI()
         configureNavigationItems()
@@ -100,5 +100,13 @@ extension JournalListViewController: UITableViewDataSource {
 extension JournalListViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         90
+    }
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let journal = viewModel.journals[indexPath.row]
+        let viewController = JournalDetailTableViewController(
+            viewModel: JournalDetailTableViewModel(journal: journal)
+        )
+        show(viewController, sender: self)
     }
 }

--- a/JRNL-Programmatically/ViewModel/JournalFlow/JournalDetailTableViewModel.swift
+++ b/JRNL-Programmatically/ViewModel/JournalFlow/JournalDetailTableViewModel.swift
@@ -1,0 +1,45 @@
+//
+//  JournalDetailTableViewModel.swift
+//  JRNL-Programmatically
+//
+//  Created by jinwoong Kim on 5/10/24.
+//
+
+import UIKit
+
+final class JournalDetailTableViewModel {
+    private let journal: Journal
+    private(set) var fields: [any CommonField] = []
+    
+    init(journal: Journal) {
+        self.journal = journal
+        
+        let dateField = CellField<JournalDetailTableLabelCell>(
+            cellContentType: .label(
+                journal.date.formatted(.dateTime.year().month().day()),
+                .right
+            )
+        )
+        let titleField = CellField<JournalDetailTableLabelCell>(
+            cellContentType: .label(
+                journal.journalTitle,
+                .left
+            )
+        )
+        let textField = CellField<JournalDetailTableTextCell>(
+            cellContentType: .text(journal.journalDescription),
+            height: 150
+        )
+        let imageField = CellField<JournalDetailTableImageCell>(
+            cellContentType: .image(journal.photoUrl ?? ""),
+            height: 316
+        )
+        
+        self.fields = [
+            dateField,
+            titleField,
+            textField,
+            imageField
+        ]
+    }
+}


### PR DESCRIPTION
## Changes
### 1. Add `BaseTableViewCell`
- it is the super class of each table view cell
### 2. Add `CommonField` and `CellField`
- `CellField` conforms `CommonField`
- `CommonField` requires two properties and two methods
    - `cellContentType` property has component value and alignment optionally.
    - `height` property represents the height of cell itself
    - `register(for:)` method furnishes the registration of underlying type's cell
    - `dequeue(for:at:)` method returns the underlying type's cell
### 3. `JournalDetailTableView` and its view model
- view model has a property named fields conforms `CommonField`
- `JournalDetailTableViewController` is a subclass of `UITableViewController`
- it regists and dequeues each cell using its view model
- also configures each cell height